### PR TITLE
Remove claims of Centos support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,7 @@ The following platforms are supported by this cookbook, meaning that the recipes
 
 * Ubuntu
 * Debian
-* RedHat
-* CentOS
 * Scientific
-* Fedora
 * SUSE
 * Amazon
 


### PR DESCRIPTION
The init-script provided for monit is debian-specific and utterly fails on Centos
